### PR TITLE
Fix high-severity bugs in OpenMP labs

### DIFF
--- a/Labs/Lab1/Solutions/exercise1.c
+++ b/Labs/Lab1/Solutions/exercise1.c
@@ -5,9 +5,9 @@ int main() {
     #pragma omp parallel num_threads(10)
     {
         if (omp_get_thread_num() % 2)
-            printf("Hello from thread %d I am Even\n",omp_get_thread_num());
-        else
             printf("Hello from thread %d I am Odd\n",omp_get_thread_num());
+        else
+            printf("Hello from thread %d I am Even\n",omp_get_thread_num());
     }
     return 0;
 }

--- a/Labs/Lab1/Solutions/exercise2.c
+++ b/Labs/Lab1/Solutions/exercise2.c
@@ -14,7 +14,7 @@ int main() {
     int Array[100];
     int max = 0;
     int min = 100000;
-    int avg;
+    int avg = 0;
 
     // We will cover this line in the next section
     omp_set_dynamic(0);

--- a/Labs/Lab4/C/explicit_map.c
+++ b/Labs/Lab4/C/explicit_map.c
@@ -1,4 +1,5 @@
 #include <stdio.h>
+#include <stdlib.h>
 #include <omp.h>
 #include <string.h>
 

--- a/Labs/Lab4/C/implicit_map_pointers.c
+++ b/Labs/Lab4/C/implicit_map_pointers.c
@@ -1,4 +1,5 @@
 #include <stdio.h>
+#include <stdlib.h>
 #include <omp.h>
 
 int main() {

--- a/Labs/Lab4/C/implicit_map_struct.c
+++ b/Labs/Lab4/C/implicit_map_struct.c
@@ -1,4 +1,5 @@
 #include <stdio.h>
+#include <stdlib.h>
 #include <omp.h>
 
 typedef struct myS{

--- a/Labs/Lab4/C/target_data_simulation.c
+++ b/Labs/Lab4/C/target_data_simulation.c
@@ -1,5 +1,6 @@
 #include <omp.h>
 #include <stdio.h>
+#include <stdlib.h>
 
 #define N 10000
 #define STEPS 50000

--- a/Labs/Lab4/C/target_only.c
+++ b/Labs/Lab4/C/target_only.c
@@ -1,5 +1,6 @@
 #include <omp.h>
 #include <stdio.h>
+#include <stdlib.h>
 
 #define N 1000000
 

--- a/Labs/Lab4/C/target_teams_parallel.c
+++ b/Labs/Lab4/C/target_teams_parallel.c
@@ -1,5 +1,6 @@
 #include <omp.h>
 #include <stdio.h>
+#include <stdlib.h>
 
 #define N 1000000
 

--- a/Labs/Lab4/Exercises/exercise3.c
+++ b/Labs/Lab4/Exercises/exercise3.c
@@ -1,5 +1,6 @@
 #include <omp.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <math.h>
 
 #define N 100000

--- a/Labs/Lab4/Solutions/exercise3.c
+++ b/Labs/Lab4/Solutions/exercise3.c
@@ -1,5 +1,6 @@
 #include <omp.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <math.h>
 
 #define N 100000000


### PR DESCRIPTION
## Summary

Fixes the three **high-severity** correctness bugs found during a review of the OpenMP labs.

## Fixes

| File(s) | Bug | Fix |
|---------|-----|-----|
| `Labs/Lab1/Solutions/exercise1.c` | Reference solution printed **Even/Odd backwards** — `n % 2` is truthy for *odd* thread numbers but printed "Even". The wrong answer is what students check against. | Swap the two strings |
| `Labs/Lab1/Solutions/exercise2.c` | `int avg;` was **uninitialized** but used in `reduction(+:avg)`. A reduction folds in the original value, so the printed average was `garbage + sum`. | `int avg = 0;` |
| `Labs/Lab4` — 8 files | `malloc` called with **no `#include <stdlib.h>`**. On clang 16+ an implicit declaration is a hard compile error; otherwise the pointer is truncated to `int` on 64-bit targets. | Add `#include <stdlib.h>` |

Lab4 files touched: `explicit_map.c`, `implicit_map_pointers.c`, `implicit_map_struct.c`, `target_only.c`, `target_teams_parallel.c`, `target_data_simulation.c`, `Exercises/exercise3.c`, `Solutions/exercise3.c`.

## Verification

- Diffs are minimal (string swap, one initializer, one include per file) and were eyeballed.
- **Not compiled** — the review host has no `-fopenmp` toolchain. Please run `clang -fopenmp` (and `-fopenmp-targets=…` / `-lm` for Lab4) on the cluster to confirm.
- **Notebook outputs need regenerating** on the cluster so captured cell output (esp. the Lab1 Even/Odd run) matches the corrected sources.

## Not in this PR

Medium/low items left for follow-up: uninitialized `firstprivate` in `Lab2/C/for_private_loop.c`, the convoluted level-walk loop in `active_levels2.c`, the non-conforming host `teams` in `thread_limit.c`, notebook typos, and the stale README scope line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)