### PR TITLE
HPCSS2026: run OpenMP labs on the Slurm compute nodes (srun + GPU offload)

### DIFF
--- a/Labs/Lab1/lab1.ipynb
+++ b/Labs/Lab1/lab1.ipynb
@@ -164,7 +164,7 @@
    "outputs": [],
    "source": [
     "# First, let's compile it\n",
-    "!gcc -fopenmp C/parallel.c -o C/parallel.exe"
+    "!srun -N 1 -c 8 gcc -fopenmp C/parallel.c -o C/parallel.exe"
    ]
   },
   {
@@ -191,7 +191,7 @@
    ],
    "source": [
     "# Now it is time to run it.\n",
-    "!C/./parallel.exe"
+    "!srun -N 1 -c 8 C/./parallel.exe"
    ]
   },
   {
@@ -265,7 +265,7 @@
     }
    ],
    "source": [
-    "!gcc -fopenmp Exercises/exercise1.c -o Exercises/exercise1.exe && Exercises/./exercise1.exe"
+    "!srun -N 1 -c 8 gcc -fopenmp Exercises/exercise1.c -o Exercises/exercise1.exe && Exercises/./exercise1.exe"
    ]
   },
   {
@@ -298,7 +298,7 @@
     }
    ],
    "source": [
-    "!gcc -fopenmp Solutions/exercise1.c -o Solutions/exercise1.exe && Solutions/./exercise1.exe"
+    "!srun -N 1 -c 8 gcc -fopenmp Solutions/exercise1.c -o Solutions/exercise1.exe && Solutions/./exercise1.exe"
    ]
   },
   {
@@ -339,7 +339,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!gcc -fopenmp C/memory.c -o C/memory.exe"
+    "!srun -N 1 -c 8 gcc -fopenmp C/memory.c -o C/memory.exe"
    ]
   },
   {
@@ -376,7 +376,7 @@
     }
    ],
    "source": [
-    "!C/./memory.exe"
+    "!srun -N 1 -c 8 C/./memory.exe"
    ]
   },
   {
@@ -415,7 +415,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!gcc -fopenmp C/datarace.c -o C/datarace.exe"
+    "!srun -N 1 -c 8 gcc -fopenmp C/datarace.c -o C/datarace.exe"
    ]
   },
   {
@@ -432,7 +432,7 @@
     }
    ],
    "source": [
-    "!C/./datarace.exe"
+    "!srun -N 1 -c 8 C/./datarace.exe"
    ]
   },
   {
@@ -487,7 +487,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!gcc -fopenmp C/atomic.c -o C/atomic.exe"
+    "!srun -N 1 -c 8 gcc -fopenmp C/atomic.c -o C/atomic.exe"
    ]
   },
   {
@@ -504,7 +504,7 @@
     }
    ],
    "source": [
-    "!C/./atomic.exe"
+    "!srun -N 1 -c 8 C/./atomic.exe"
    ]
   },
   {
@@ -536,7 +536,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!gcc -fopenmp C/private.c -o C/private.exe"
+    "!srun -N 1 -c 8 gcc -fopenmp C/private.c -o C/private.exe"
    ]
   },
   {
@@ -563,7 +563,7 @@
     }
    ],
    "source": [
-    "!C/./private.exe"
+    "!srun -N 1 -c 8 C/./private.exe"
    ]
   },
   {
@@ -601,7 +601,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!gcc -fopenmp C/firstprivate.c -o C/firstprivate.exe"
+    "!srun -N 1 -c 8 gcc -fopenmp C/firstprivate.c -o C/firstprivate.exe"
    ]
   },
   {
@@ -628,7 +628,7 @@
     }
    ],
    "source": [
-    "!C/./firstprivate.exe"
+    "!srun -N 1 -c 8 C/./firstprivate.exe"
    ]
   },
   {
@@ -702,7 +702,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!gcc -fopenmp C/reductions.c -o C/reductions.exe"
+    "!srun -N 1 -c 8 gcc -fopenmp C/reductions.c -o C/reductions.exe"
    ]
   },
   {
@@ -722,7 +722,7 @@
     }
    ],
    "source": [
-    "!C/./reductions.exe"
+    "!srun -N 1 -c 8 C/./reductions.exe"
    ]
   },
   {
@@ -765,7 +765,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!gcc -fopenmp C/lastprivate.c -o C/lastprivate.exe"
+    "!srun -N 1 -c 8 gcc -fopenmp C/lastprivate.c -o C/lastprivate.exe"
    ]
   },
   {
@@ -782,7 +782,7 @@
     }
    ],
    "source": [
-    "!C/./lastprivate.exe"
+    "!srun -N 1 -c 8 C/./lastprivate.exe"
    ]
   },
   {
@@ -814,7 +814,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!gcc -fopenmp Exercises/exercise2.c -o Exercises/exercise2.exe && Exercises/./exercise2.exe"
+    "!srun -N 1 -c 8 gcc -fopenmp Exercises/exercise2.c -o Exercises/exercise2.exe && Exercises/./exercise2.exe"
    ]
   },
   {
@@ -841,7 +841,7 @@
     }
    ],
    "source": [
-    "!gcc -fopenmp Solutions/exercise2.c -o Solutions/exercise2.exe && Solutions/./exercise2.exe"
+    "!srun -N 1 -c 8 gcc -fopenmp Solutions/exercise2.c -o Solutions/exercise2.exe && Solutions/./exercise2.exe"
    ]
   }
  ],

--- a/Labs/Lab2/lab2.1.ipynb
+++ b/Labs/Lab2/lab2.1.ipynb
@@ -74,7 +74,7 @@
    "outputs": [],
    "source": [
     "# First, let's compile it\n",
-    "!clang -fopenmp C/hello_world.c -o C/hello_world.exe"
+    "!srun -N 1 -c 8 clang -fopenmp C/hello_world.c -o C/hello_world.exe"
    ]
   },
   {
@@ -86,7 +86,7 @@
     "# Now let's run it with different values\n",
     "\n",
     "#Running with default num threads. Implementation defined\n",
-    "!C/./hello_world.exe"
+    "!srun -N 1 -c 8 C/./hello_world.exe"
    ]
   },
   {
@@ -96,7 +96,7 @@
    "outputs": [],
    "source": [
     "#Running with different num threads modifying OMP_NUM_THREADS\n",
-    "!OMP_NUM_THREADS=3 C/./hello_world.exe"
+    "!OMP_NUM_THREADS=3 srun -N 1 -c 8 C/./hello_world.exe"
    ]
   },
   {
@@ -106,7 +106,7 @@
    "outputs": [],
    "source": [
     "#Running with different num threads modifying OMP_NUM_THREADS\n",
-    "!OMP_NUM_THREADS=5 C/./hello_world.exe"
+    "!OMP_NUM_THREADS=5 srun -N 1 -c 8 C/./hello_world.exe"
    ]
   },
   {
@@ -142,7 +142,7 @@
    "outputs": [],
    "source": [
     "#Building the hello world program\n",
-    "!clang -fopenmp C/./hello_world.c -o C/hello_world.exe"
+    "!srun -N 1 -c 8 clang -fopenmp C/./hello_world.c -o C/hello_world.exe"
    ]
   },
   {
@@ -152,7 +152,7 @@
    "outputs": [],
    "source": [
     "# Running it with OMP_THREAD_LIMIT\n",
-    "!OMP_THREAD_LIMIT=4 OMP_NUM_THREADS=1000 C/./hello_world.exe"
+    "!OMP_THREAD_LIMIT=4 OMP_NUM_THREADS=1000 srun -N 1 -c 8 C/./hello_world.exe"
    ]
   },
   {
@@ -187,7 +187,7 @@
    "outputs": [],
    "source": [
     "#Building the program\n",
-    "!clang -fopenmp C/omp_set_num_threads.c -o C/omp_set_num_threads.exe"
+    "!srun -N 1 -c 8 clang -fopenmp C/omp_set_num_threads.c -o C/omp_set_num_threads.exe"
    ]
   },
   {
@@ -197,7 +197,7 @@
    "outputs": [],
    "source": [
     "#Running the program\n",
-    "!C/./omp_set_num_threads.exe"
+    "!srun -N 1 -c 8 C/./omp_set_num_threads.exe"
    ]
   },
   {
@@ -207,7 +207,7 @@
    "outputs": [],
    "source": [
     "#Running the program trying to force num threads with env variable\n",
-    "!OMP_NUM_THREADS=1000 C/./omp_set_num_threads.exe"
+    "!OMP_NUM_THREADS=1000 srun -N 1 -c 8 C/./omp_set_num_threads.exe"
    ]
   },
   {
@@ -244,7 +244,7 @@
    "outputs": [],
    "source": [
     "#Building the program\n",
-    "!clang -fopenmp C/num_threads.c -o C/num_threads.exe"
+    "!srun -N 1 -c 8 clang -fopenmp C/num_threads.c -o C/num_threads.exe"
    ]
   },
   {
@@ -254,7 +254,7 @@
    "outputs": [],
    "source": [
     "# Running\n",
-    "!C/./num_threads.exe"
+    "!srun -N 1 -c 8 C/./num_threads.exe"
    ]
   },
   {
@@ -264,7 +264,7 @@
    "outputs": [],
    "source": [
     "# Running with OMP_NUM_THREADS to demonstrate precedence\n",
-    "!OMP_NUM_THREADS=1000 C/./num_threads.exe"
+    "!OMP_NUM_THREADS=1000 srun -N 1 -c 8 C/./num_threads.exe"
    ]
   },
   {
@@ -292,7 +292,7 @@
    "outputs": [],
    "source": [
     "# Building\n",
-    "!clang -fopenmp C/num_threads_mixed.c -o C/num_threads_mixed.exe"
+    "!srun -N 1 -c 8 clang -fopenmp C/num_threads_mixed.c -o C/num_threads_mixed.exe"
    ]
   },
   {
@@ -302,7 +302,7 @@
    "outputs": [],
    "source": [
     "# Running\n",
-    "!OMP_NUM_THREADS=1 C/./num_threads_mixed.exe"
+    "!OMP_NUM_THREADS=1 srun -N 1 -c 8 C/./num_threads_mixed.exe"
    ]
   },
   {
@@ -338,7 +338,7 @@
    "outputs": [],
    "source": [
     "# Building\n",
-    "!clang -fopenmp C/parallel_if.c -o C/parallel_if.exe"
+    "!srun -N 1 -c 8 clang -fopenmp C/parallel_if.c -o C/parallel_if.exe"
    ]
   },
   {
@@ -348,7 +348,7 @@
    "outputs": [],
    "source": [
     "# Running\n",
-    "!C/./parallel_if.exe"
+    "!srun -N 1 -c 8 C/./parallel_if.exe"
    ]
   },
   {
@@ -396,7 +396,7 @@
    "outputs": [],
    "source": [
     "#building the example\n",
-    "!clang -fopenmp C/lock_program.c -o C/lock_program.exe"
+    "!srun -N 1 -c 8 clang -fopenmp C/lock_program.c -o C/lock_program.exe"
    ]
   },
   {
@@ -406,7 +406,7 @@
    "outputs": [],
    "source": [
     "#Executing with many threads\n",
-    "!OMP_NUM_THREADS=4 C/./lock_program.exe"
+    "!OMP_NUM_THREADS=4 srun -N 1 -c 8 C/./lock_program.exe"
    ]
   },
   {
@@ -416,7 +416,7 @@
    "outputs": [],
    "source": [
     "#Executing with timeout to avoid locking this cell\n",
-    "!OMP_NUM_THREADS=1 timeout 10 C/./lock_program.exe || if [ $? -eq 124 ]; then echo \"Program took too long\"; fi"
+    "!OMP_NUM_THREADS=1 srun -N 1 -c 8 timeout 10 C/./lock_program.exe || if [ $? -eq 124 ]; then echo \"Program took too long\"; fi"
    ]
   },
   {
@@ -433,7 +433,7 @@
    "outputs": [],
    "source": [
     "# Building\n",
-    "!clang -fopenmp C/lock_safe_program.c -o C/lock_safe_program.exe"
+    "!srun -N 1 -c 8 clang -fopenmp C/lock_safe_program.c -o C/lock_safe_program.exe"
    ]
   },
   {
@@ -443,7 +443,7 @@
    "outputs": [],
    "source": [
     "# Running with sufficient threads\n",
-    "!OMP_NUM_THREADS=4 C/./lock_safe_program.exe"
+    "!OMP_NUM_THREADS=4 srun -N 1 -c 8 C/./lock_safe_program.exe"
    ]
   },
   {
@@ -453,7 +453,7 @@
    "outputs": [],
    "source": [
     "# Running without sufficient threads\n",
-    "!OMP_NUM_THREADS=1 C/./lock_safe_program.exe"
+    "!OMP_NUM_THREADS=1 srun -N 1 -c 8 C/./lock_safe_program.exe"
    ]
   },
   {
@@ -509,7 +509,7 @@
    "outputs": [],
    "source": [
     "# Building\n",
-    "!clang -fopenmp C/teams.c -o C/teams.exe"
+    "!srun -N 1 -c 8 clang -fopenmp C/teams.c -o C/teams.exe"
    ]
   },
   {
@@ -519,7 +519,7 @@
    "outputs": [],
    "source": [
     "# Compiling\n",
-    "!C/./teams.exe"
+    "!srun -N 1 -c 8 C/./teams.exe"
    ]
   },
   {
@@ -561,7 +561,7 @@
    "outputs": [],
    "source": [
     "#building (using GCC due to poor support in clang of teams in the host)\n",
-    "!gcc -fopenmp C/teams_parallel.c -o C/teams_parallel.exe"
+    "!srun -N 1 -c 8 gcc -fopenmp C/teams_parallel.c -o C/teams_parallel.exe"
    ]
   },
   {
@@ -571,7 +571,7 @@
    "outputs": [],
    "source": [
     "#Running\n",
-    "!C/./teams_parallel.exe"
+    "!srun -N 1 -c 8 C/./teams_parallel.exe"
    ]
   },
   {
@@ -621,7 +621,7 @@
    "outputs": [],
    "source": [
     "#Building (Using GCC due to a limited implementation in clang)\n",
-    "!gcc -fopenmp C/thread_limit.c -o C/thread_limit.exe"
+    "!srun -N 1 -c 8 gcc -fopenmp C/thread_limit.c -o C/thread_limit.exe"
    ]
   },
   {
@@ -631,7 +631,7 @@
    "outputs": [],
    "source": [
     "#Running\n",
-    "!C/./thread_limit.exe"
+    "!srun -N 1 -c 8 C/./thread_limit.exe"
    ]
   },
   {
@@ -676,7 +676,7 @@
    "outputs": [],
    "source": [
     "#build\n",
-    "!clang -fopenmp C/levels.c -o C/levels.exe"
+    "!srun -N 1 -c 8 clang -fopenmp C/levels.c -o C/levels.exe"
    ]
   },
   {
@@ -686,7 +686,7 @@
    "outputs": [],
    "source": [
     "#Execute\n",
-    "!C/./levels.exe"
+    "!srun -N 1 -c 8 C/./levels.exe"
    ]
   },
   {
@@ -722,7 +722,7 @@
    "outputs": [],
    "source": [
     "#Build\n",
-    "!clang -fopenmp C/active_levels.c -o C/active_levels.exe"
+    "!srun -N 1 -c 8 clang -fopenmp C/active_levels.c -o C/active_levels.exe"
    ]
   },
   {
@@ -732,7 +732,7 @@
    "outputs": [],
    "source": [
     "#Execute\n",
-    "!OMP_MAX_ACTIVE_LEVELS=3 C/./active_levels.exe"
+    "!OMP_MAX_ACTIVE_LEVELS=3 srun -N 1 -c 8 C/./active_levels.exe"
    ]
   },
   {
@@ -782,7 +782,7 @@
    "outputs": [],
    "source": [
     "#Build\n",
-    "!clang -fopenmp C/active_levels2.c -o C/active_levels2.exe"
+    "!srun -N 1 -c 8 clang -fopenmp C/active_levels2.c -o C/active_levels2.exe"
    ]
   },
   {
@@ -792,7 +792,7 @@
    "outputs": [],
    "source": [
     "#Execute\n",
-    "!OMP_MAX_ACTIVE_LEVELS=3 C/./active_levels2.exe"
+    "!OMP_MAX_ACTIVE_LEVELS=3 srun -N 1 -c 8 C/./active_levels2.exe"
    ]
   },
   {

--- a/Labs/Lab2/lab2.2.ipynb
+++ b/Labs/Lab2/lab2.2.ipynb
@@ -53,7 +53,7 @@
    "outputs": [],
    "source": [
     "#build\n",
-    "!clang -fopenmp C/simple_parallel.c -o C/simple_parallel.exe"
+    "!srun -N 1 -c 8 clang -fopenmp C/simple_parallel.c -o C/simple_parallel.exe"
    ]
   },
   {
@@ -71,7 +71,7 @@
    ],
    "source": [
     "#execute\n",
-    "!C/./simple_parallel.exe"
+    "!srun -N 1 -c 8 C/./simple_parallel.exe"
    ]
   },
   {
@@ -111,7 +111,7 @@
    "outputs": [],
    "source": [
     "#build\n",
-    "!clang -fopenmp C/not_recommended_parallel_if.c -o C/not_recommended_parallel_if.exe"
+    "!srun -N 1 -c 8 clang -fopenmp C/not_recommended_parallel_if.c -o C/not_recommended_parallel_if.exe"
    ]
   },
   {
@@ -130,7 +130,7 @@
    ],
    "source": [
     "#execute\n",
-    "!C/./not_recommended_parallel_if.exe"
+    "!srun -N 1 -c 8 C/./not_recommended_parallel_if.exe"
    ]
   },
   {
@@ -171,7 +171,7 @@
    "outputs": [],
    "source": [
     "#build\n",
-    "!clang -fopenmp C/parallel_masked.c -o C/parallel_masked.exe"
+    "!srun -N 1 -c 8 clang -fopenmp C/parallel_masked.c -o C/parallel_masked.exe"
    ]
   },
   {
@@ -190,7 +190,7 @@
    ],
    "source": [
     "#execute\n",
-    "!C/./parallel_masked.exe"
+    "!srun -N 1 -c 8 C/./parallel_masked.exe"
    ]
   },
   {
@@ -229,7 +229,7 @@
    "outputs": [],
    "source": [
     "#build\n",
-    "!clang -fopenmp C/parallel_single.c -o C/parallel_single.exe"
+    "!srun -N 1 -c 8 clang -fopenmp C/parallel_single.c -o C/parallel_single.exe"
    ]
   },
   {
@@ -249,7 +249,7 @@
    ],
    "source": [
     "#execute\n",
-    "!C/./parallel_single.exe"
+    "!srun -N 1 -c 8 C/./parallel_single.exe"
    ]
   },
   {
@@ -282,7 +282,7 @@
    "outputs": [],
    "source": [
     "#build\n",
-    "!clang -fopenmp C/single_barrier.c -o C/single_barrier.exe"
+    "!srun -N 1 -c 8 clang -fopenmp C/single_barrier.c -o C/single_barrier.exe"
    ]
   },
   {
@@ -300,7 +300,7 @@
    ],
    "source": [
     "#execute\n",
-    "!C/./single_barrier.exe"
+    "!srun -N 1 -c 8 C/./single_barrier.exe"
    ]
   },
   {
@@ -336,7 +336,7 @@
    "outputs": [],
    "source": [
     "#build\n",
-    "!clang -fopenmp Exercises/single_no_barrier.c -o Exercises/single_no_barrier.exe"
+    "!srun -N 1 -c 8 clang -fopenmp Exercises/single_no_barrier.c -o Exercises/single_no_barrier.exe"
    ]
   },
   {
@@ -363,7 +363,7 @@
    ],
    "source": [
     "#execute 10 times\n",
-    "!for i in `seq 10`; do Exercises/./single_no_barrier.exe; done"
+    "!for i in `seq 10`; do srun -N 1 -c 8 Exercises/./single_no_barrier.exe; done"
    ]
   },
   {
@@ -405,7 +405,7 @@
    "outputs": [],
    "source": [
     "#build\n",
-    "!clang -fopenmp C/broken_code_no_critical.c -o C/broken_code_no_critical.exe"
+    "!srun -N 1 -c 8 clang -fopenmp C/broken_code_no_critical.c -o C/broken_code_no_critical.exe"
    ]
   },
   {
@@ -432,7 +432,7 @@
    ],
    "source": [
     "#execute\n",
-    "!C/./broken_code_no_critical.exe"
+    "!srun -N 1 -c 8 C/./broken_code_no_critical.exe"
    ]
   },
   {
@@ -486,7 +486,7 @@
    "outputs": [],
    "source": [
     "#build\n",
-    "!clang -fopenmp C/critical_array_order.c -o C/critical_array_order.exe"
+    "!srun -N 1 -c 8 clang -fopenmp C/critical_array_order.c -o C/critical_array_order.exe"
    ]
   },
   {
@@ -513,7 +513,7 @@
    ],
    "source": [
     "#execute\n",
-    "!C/./critical_array_order.exe"
+    "!srun -N 1 -c 8 C/./critical_array_order.exe"
    ]
   },
   {
@@ -545,7 +545,7 @@
    "outputs": [],
    "source": [
     "#build\n",
-    "!clang++ -fopenmp Exercises/critical_region_queue.cpp -o Exercises/critical_region_queue.exe"
+    "!srun -N 1 -c 8 clang++ -fopenmp Exercises/critical_region_queue.cpp -o Exercises/critical_region_queue.exe"
    ]
   },
   {
@@ -563,7 +563,7 @@
    ],
    "source": [
     "#execute\n",
-    "!Exercises/./critical_region_queue.exe"
+    "!srun -N 1 -c 8 Exercises/./critical_region_queue.exe"
    ]
   },
   {
@@ -580,7 +580,7 @@
    "outputs": [],
    "source": [
     "#build\n",
-    "!clang++ -fopenmp Solutions/critical_region_queue.cpp -o Solutions/critical_region_queue.exe"
+    "!srun -N 1 -c 8 clang++ -fopenmp Solutions/critical_region_queue.cpp -o Solutions/critical_region_queue.exe"
    ]
   },
   {
@@ -697,7 +697,7 @@
    ],
    "source": [
     "#execute\n",
-    "!Solutions/./critical_region_queue.exe"
+    "!srun -N 1 -c 8 Solutions/./critical_region_queue.exe"
    ]
   },
   {
@@ -751,7 +751,7 @@
    "outputs": [],
    "source": [
     "#build\n",
-    "!clang -fopenmp C/sections.c -o C/sections.exe"
+    "!srun -N 1 -c 8 clang -fopenmp C/sections.c -o C/sections.exe"
    ]
   },
   {
@@ -798,7 +798,7 @@
    ],
    "source": [
     "#execute\n",
-    "!C/./sections.exe"
+    "!srun -N 1 -c 8 C/./sections.exe"
    ]
   },
   {
@@ -839,7 +839,7 @@
    "outputs": [],
    "source": [
     "#build\n",
-    "!clang -fopenmp C/barriers.c -o C/barriers.exe"
+    "!srun -N 1 -c 8 clang -fopenmp C/barriers.c -o C/barriers.exe"
    ]
   },
   {
@@ -866,7 +866,7 @@
    ],
    "source": [
     "#execute\n",
-    "!C/./barriers.exe"
+    "!srun -N 1 -c 8 C/./barriers.exe"
    ]
   },
   {
@@ -908,7 +908,7 @@
    "outputs": [],
    "source": [
     "#build\n",
-    "!clang++ -fopenmp C/parallel_time_creation.cpp -o C/parallel_time_creation.exe"
+    "!srun -N 1 -c 8 clang++ -fopenmp C/parallel_time_creation.cpp -o C/parallel_time_creation.exe"
    ]
   },
   {
@@ -927,7 +927,7 @@
    ],
    "source": [
     "#execute\n",
-    "!C/./parallel_time_creation.exe"
+    "!srun -N 1 -c 8 C/./parallel_time_creation.exe"
    ]
   },
   {
@@ -980,7 +980,7 @@
    "outputs": [],
    "source": [
     "#build\n",
-    "!clang -fopenmp C/for_loop.c -o C/for_loop.exe"
+    "!srun -N 1 -c 8 clang -fopenmp C/for_loop.c -o C/for_loop.exe"
    ]
   },
   {
@@ -1007,7 +1007,7 @@
    ],
    "source": [
     "#execute\n",
-    "!C/./for_loop.exe"
+    "!srun -N 1 -c 8 C/./for_loop.exe"
    ]
   },
   {
@@ -1062,7 +1062,7 @@
    "outputs": [],
    "source": [
     "#build\n",
-    "!clang -fopenmp C/for_private_loop.c -o C/for_private_loop.exe"
+    "!srun -N 1 -c 8 clang -fopenmp C/for_private_loop.c -o C/for_private_loop.exe"
    ]
   },
   {
@@ -1089,7 +1089,7 @@
    ],
    "source": [
     "#execute\n",
-    "!C/./for_private_loop.exe"
+    "!srun -N 1 -c 8 C/./for_private_loop.exe"
    ]
   },
   {
@@ -1236,7 +1236,7 @@
    "outputs": [],
    "source": [
     "#build\n",
-    "!clang -fopenmp C/for_loop_static.c -o C/for_loop_static.exe"
+    "!srun -N 1 -c 8 clang -fopenmp C/for_loop_static.c -o C/for_loop_static.exe"
    ]
   },
   {
@@ -1263,7 +1263,7 @@
    ],
    "source": [
     "#execute\n",
-    "!C/./for_loop_static.exe"
+    "!srun -N 1 -c 8 C/./for_loop_static.exe"
    ]
   },
   {
@@ -1290,7 +1290,7 @@
    "outputs": [],
    "source": [
     "#build\n",
-    "!clang -fopenmp C/for_loop_dynamic.c -o C/for_loop_dynamic.exe"
+    "!srun -N 1 -c 8 clang -fopenmp C/for_loop_dynamic.c -o C/for_loop_dynamic.exe"
    ]
   },
   {
@@ -1317,7 +1317,7 @@
    ],
    "source": [
     "#execute\n",
-    "!C/./for_loop_dynamic.exe"
+    "!srun -N 1 -c 8 C/./for_loop_dynamic.exe"
    ]
   },
   {
@@ -1344,7 +1344,7 @@
    "outputs": [],
    "source": [
     "#build\n",
-    "!clang -fopenmp C/for_loop_guided.c -o C/for_loop_guided.exe"
+    "!srun -N 1 -c 8 clang -fopenmp C/for_loop_guided.c -o C/for_loop_guided.exe"
    ]
   },
   {
@@ -1381,7 +1381,7 @@
    ],
    "source": [
     "#execute\n",
-    "!C/./for_loop_guided.exe"
+    "!srun -N 1 -c 8 C/./for_loop_guided.exe"
    ]
   },
   {
@@ -1408,7 +1408,7 @@
    "outputs": [],
    "source": [
     "#build\n",
-    "!clang -fopenmp C/for_loop_auto.c -o C/for_loop_auto.exe"
+    "!srun -N 1 -c 8 clang -fopenmp C/for_loop_auto.c -o C/for_loop_auto.exe"
    ]
   },
   {
@@ -1435,7 +1435,7 @@
    ],
    "source": [
     "#execute\n",
-    "!C/./for_loop_auto.exe"
+    "!srun -N 1 -c 8 C/./for_loop_auto.exe"
    ]
   },
   {
@@ -1462,7 +1462,7 @@
    "outputs": [],
    "source": [
     "#build\n",
-    "!clang -fopenmp C/for_loop_runtime.c -o C/for_loop_runtime.exe"
+    "!srun -N 1 -c 8 clang -fopenmp C/for_loop_runtime.c -o C/for_loop_runtime.exe"
    ]
   },
   {
@@ -1489,7 +1489,7 @@
    ],
    "source": [
     "#execute\n",
-    "!C/./for_loop_runtime.exe"
+    "!srun -N 1 -c 8 C/./for_loop_runtime.exe"
    ]
   },
   {
@@ -1516,7 +1516,7 @@
    ],
    "source": [
     "#execute\n",
-    "!OMP_SCHEDULE=\"static,5\" C/./for_loop_runtime.exe"
+    "!OMP_SCHEDULE=\"static,5\" srun -N 1 -c 8 C/./for_loop_runtime.exe"
    ]
   },
   {
@@ -1543,7 +1543,7 @@
    ],
    "source": [
     "#execute\n",
-    "!OMP_SCHEDULE=\"dynamic,2\" C/./for_loop_runtime.exe"
+    "!OMP_SCHEDULE=\"dynamic,2\" srun -N 1 -c 8 C/./for_loop_runtime.exe"
    ]
   },
   {
@@ -1576,7 +1576,7 @@
    "outputs": [],
    "source": [
     "#build\n",
-    "!clang -fopenmp Exercises/matrix_mult.c -o Exercises/matrix_mult.exe"
+    "!srun -N 1 -c 8 clang -fopenmp Exercises/matrix_mult.c -o Exercises/matrix_mult.exe"
    ]
   },
   {
@@ -1603,7 +1603,7 @@
    ],
    "source": [
     "#execute\n",
-    "!Exercises/./matrix_mult.exe"
+    "!srun -N 1 -c 8 Exercises/./matrix_mult.exe"
    ]
   },
   {
@@ -1627,7 +1627,7 @@
    "outputs": [],
    "source": [
     "#build\n",
-    "!gcc -fopenmp Solutions/matrix_mult.c -o Solutions/matrix_mult.exe -O3"
+    "!srun -N 1 -c 8 gcc -fopenmp Solutions/matrix_mult.c -o Solutions/matrix_mult.exe -O3"
    ]
   },
   {
@@ -1646,7 +1646,7 @@
    ],
    "source": [
     "#execute\n",
-    "!Solutions/./matrix_mult.exe"
+    "!srun -N 1 -c 8 Solutions/./matrix_mult.exe"
    ]
   },
   {

--- a/Labs/Lab4/lab4.1.ipynb
+++ b/Labs/Lab4/lab4.1.ipynb
@@ -185,7 +185,7 @@
    "outputs": [],
    "source": [
     "# Building this code\n",
-    "!clang -fopenmp -fopenmp-targets=nvptx64 C/simple_target.c -o C/simple_target.exe"
+    "!srun -N 1 -c 8 clang -fopenmp -fopenmp-targets=nvptx64 C/simple_target.c -o C/simple_target.exe"
    ]
   },
   {
@@ -203,7 +203,7 @@
    ],
    "source": [
     "# Running the code on the host\n",
-    "!OMP_TARGET_OFFLOAD=disabled C/./simple_target.exe"
+    "!OMP_TARGET_OFFLOAD=disabled srun -N 1 -c 8 --gres=gpu:1 C/./simple_target.exe"
    ]
   },
   {
@@ -221,7 +221,7 @@
    ],
    "source": [
     "# Running the code on the host\n",
-    "!OMP_TARGET_OFFLOAD=mandatory C/./simple_target.exe"
+    "!OMP_TARGET_OFFLOAD=mandatory srun -N 1 -c 8 --gres=gpu:1 C/./simple_target.exe"
    ]
   },
   {
@@ -295,7 +295,7 @@
    "outputs": [],
    "source": [
     "# Building the example\n",
-    "!clang -fopenmp -fopenmp-targets=nvptx64 C/simple_multiple_devices.c -o C/simple_multiple_devices.exe"
+    "!srun -N 1 -c 8 clang -fopenmp -fopenmp-targets=nvptx64 C/simple_multiple_devices.c -o C/simple_multiple_devices.exe"
    ]
   },
   {
@@ -314,7 +314,7 @@
    ],
    "source": [
     "# Running the example\n",
-    "!C/./simple_multiple_devices.exe"
+    "!srun -N 1 -c 8 --gres=gpu:1 C/./simple_multiple_devices.exe"
    ]
   },
   {
@@ -358,10 +358,10 @@
    ],
    "source": [
     "# Build\n",
-    "!clang -fopenmp -fopenmp-targets=nvptx64 Exercises/exercise1.c -o Exercises/exercise1.exe\n",
+    "!srun -N 1 -c 8 clang -fopenmp -fopenmp-targets=nvptx64 Exercises/exercise1.c -o Exercises/exercise1.exe\n",
     "\n",
     "# Run\n",
-    "!Exercises/./exercise1.exe"
+    "!srun -N 1 -c 8 --gres=gpu:1 Exercises/./exercise1.exe"
    ]
   },
   {
@@ -390,10 +390,10 @@
    ],
    "source": [
     "# Build\n",
-    "!clang -fopenmp -fopenmp-targets=nvptx64 Solutions/exercise1.c -o Solutions/exercise1.exe\n",
+    "!srun -N 1 -c 8 clang -fopenmp -fopenmp-targets=nvptx64 Solutions/exercise1.c -o Solutions/exercise1.exe\n",
     "\n",
     "# Run\n",
-    "!Solutions/./exercise1.exe"
+    "!srun -N 1 -c 8 --gres=gpu:1 Solutions/./exercise1.exe"
    ]
   },
   {
@@ -439,7 +439,7 @@
    "outputs": [],
    "source": [
     "# Building this code\n",
-    "!clang -fopenmp -fopenmp-targets=nvptx64 C/different_addresses.c -o C/different_addresses.exe"
+    "!srun -N 1 -c 8 clang -fopenmp -fopenmp-targets=nvptx64 C/different_addresses.c -o C/different_addresses.exe"
    ]
   },
   {
@@ -458,7 +458,7 @@
    ],
    "source": [
     "# Running the code\n",
-    "!C/./different_addresses.exe"
+    "!srun -N 1 -c 8 --gres=gpu:1 C/./different_addresses.exe"
    ]
   },
   {
@@ -525,7 +525,7 @@
    "outputs": [],
    "source": [
     "# building\n",
-    "!clang -fopenmp -fopenmp-targets=nvptx64 C/implicit_map_scalar.c -o C/implicit_map_scalar.exe"
+    "!srun -N 1 -c 8 clang -fopenmp -fopenmp-targets=nvptx64 C/implicit_map_scalar.c -o C/implicit_map_scalar.exe"
    ]
   },
   {
@@ -544,7 +544,7 @@
    ],
    "source": [
     "# Running\n",
-    "!C/./implicit_map_scalar.exe"
+    "!srun -N 1 -c 8 --gres=gpu:1 C/./implicit_map_scalar.exe"
    ]
   },
   {
@@ -607,7 +607,7 @@
    "outputs": [],
    "source": [
     "# building\n",
-    "!clang -fopenmp -fopenmp-targets=nvptx64 C/implicit_map_struct.c -o C/implicit_map_struct.exe"
+    "!srun -N 1 -c 8 clang -fopenmp -fopenmp-targets=nvptx64 C/implicit_map_struct.c -o C/implicit_map_struct.exe"
    ]
   },
   {
@@ -627,7 +627,7 @@
    ],
    "source": [
     "# Running\n",
-    "!C/./implicit_map_struct.exe"
+    "!srun -N 1 -c 8 --gres=gpu:1 C/./implicit_map_struct.exe"
    ]
   },
   {
@@ -677,7 +677,7 @@
    "outputs": [],
    "source": [
     "# building\n",
-    "!clang -fopenmp -fopenmp-targets=nvptx64 C/implicit_map_arrays.c -o C/implicit_map_arrays.exe"
+    "!srun -N 1 -c 8 clang -fopenmp -fopenmp-targets=nvptx64 C/implicit_map_arrays.c -o C/implicit_map_arrays.exe"
    ]
   },
   {
@@ -697,7 +697,7 @@
    ],
    "source": [
     "# Running\n",
-    "!C/./implicit_map_arrays.exe"
+    "!srun -N 1 -c 8 --gres=gpu:1 C/./implicit_map_arrays.exe"
    ]
   },
   {
@@ -757,7 +757,7 @@
    "outputs": [],
    "source": [
     "# building\n",
-    "!clang -fopenmp -fopenmp-targets=nvptx64 C/implicit_map_pointers.c -o C/implicit_map_pointers.exe"
+    "!srun -N 1 -c 8 clang -fopenmp -fopenmp-targets=nvptx64 C/implicit_map_pointers.c -o C/implicit_map_pointers.exe"
    ]
   },
   {
@@ -778,7 +778,7 @@
    ],
    "source": [
     "# Running\n",
-    "!C/./implicit_map_pointers.exe"
+    "!srun -N 1 -c 8 --gres=gpu:1 C/./implicit_map_pointers.exe"
    ]
   },
   {
@@ -851,7 +851,7 @@
    "outputs": [],
    "source": [
     "# building\n",
-    "!clang -fopenmp -fopenmp-targets=nvptx64 C/explicit_map.c -o C/explicit_map.exe"
+    "!srun -N 1 -c 8 clang -fopenmp -fopenmp-targets=nvptx64 C/explicit_map.c -o C/explicit_map.exe"
    ]
   },
   {
@@ -893,7 +893,7 @@
    ],
    "source": [
     "# running\n",
-    "!C/./explicit_map.exe"
+    "!srun -N 1 -c 8 --gres=gpu:1 C/./explicit_map.exe"
    ]
   },
   {
@@ -958,7 +958,7 @@
    "outputs": [],
    "source": [
     "# building\n",
-    "!clang -fopenmp -fopenmp-targets=nvptx64 C/map_array_sections.c -o C/map_array_sections.exe"
+    "!srun -N 1 -c 8 clang -fopenmp -fopenmp-targets=nvptx64 C/map_array_sections.c -o C/map_array_sections.exe"
    ]
   },
   {
@@ -983,7 +983,7 @@
    ],
    "source": [
     "# running\n",
-    "!C/./map_array_sections.exe"
+    "!srun -N 1 -c 8 --gres=gpu:1 C/./map_array_sections.exe"
    ]
   },
   {
@@ -1039,7 +1039,7 @@
    "outputs": [],
    "source": [
     "# building\n",
-    "!clang -fopenmp -fopenmp-targets=nvptx64 C/target_data_simple.c -o C/target_data_simple.exe"
+    "!srun -N 1 -c 8 clang -fopenmp -fopenmp-targets=nvptx64 C/target_data_simple.c -o C/target_data_simple.exe"
    ]
   },
   {
@@ -1058,7 +1058,7 @@
    ],
    "source": [
     "# running\n",
-    "!C/./target_data_simple.exe"
+    "!srun -N 1 -c 8 --gres=gpu:1 C/./target_data_simple.exe"
    ]
   },
   {
@@ -1118,7 +1118,7 @@
    "outputs": [],
    "source": [
     "# Compiling\n",
-    "!clang -fopenmp -fopenmp-targets=nvptx64 C/target_data_simulation.c -o C/target_data_simulation.exe"
+    "!srun -N 1 -c 8 clang -fopenmp -fopenmp-targets=nvptx64 C/target_data_simulation.c -o C/target_data_simulation.exe"
    ]
   },
   {
@@ -1137,7 +1137,7 @@
    ],
    "source": [
     "# Running\n",
-    "!C/./target_data_simulation.exe"
+    "!srun -N 1 -c 8 --gres=gpu:1 C/./target_data_simulation.exe"
    ]
   },
   {
@@ -1224,7 +1224,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!clang -fopenmp -fopenmp-targets=nvptx64 C/target_update_and_enter_exit_data.c -o C/target_update_and_enter_exit_data.exe"
+    "!srun -N 1 -c 8 clang -fopenmp -fopenmp-targets=nvptx64 C/target_update_and_enter_exit_data.c -o C/target_update_and_enter_exit_data.exe"
    ]
   },
   {
@@ -1249,7 +1249,7 @@
     }
    ],
    "source": [
-    "!C/./target_update_and_enter_exit_data.exe"
+    "!srun -N 1 -c 8 --gres=gpu:1 C/./target_update_and_enter_exit_data.exe"
    ]
   },
   {
@@ -1325,7 +1325,7 @@
    "outputs": [],
    "source": [
     "# Building\n",
-    "!clang -fopenmp -fopenmp-targets=nvptx64 C/api_target_data.c -o C/api_target_data.exe"
+    "!srun -N 1 -c 8 clang -fopenmp -fopenmp-targets=nvptx64 C/api_target_data.c -o C/api_target_data.exe"
    ]
   },
   {
@@ -1340,7 +1340,7 @@
    "source": [
     "# Running and profiling\n",
     "# !nvprof --print-gpu-trace C/./api_target_data.exe\n",
-    "!C/./api_target_data.exe"
+    "!srun -N 1 -c 8 --gres=gpu:1 C/./api_target_data.exe"
    ]
   },
   {
@@ -1426,7 +1426,7 @@
    "outputs": [],
    "source": [
     "# Building\n",
-    "!clang -fopenmp -fopenmp-targets=nvptx64 C/target_is_device_ptr.c -o C/./target_is_device_ptr.exe"
+    "!srun -N 1 -c 8 clang -fopenmp -fopenmp-targets=nvptx64 C/target_is_device_ptr.c -o C/./target_is_device_ptr.exe"
    ]
   },
   {
@@ -1456,7 +1456,7 @@
    ],
    "source": [
     "# Running\n",
-    "!C/./target_is_device_ptr.exe"
+    "!srun -N 1 -c 8 --gres=gpu:1 C/./target_is_device_ptr.exe"
    ]
   },
   {
@@ -1492,10 +1492,10 @@
    "outputs": [],
    "source": [
     "# Building Solution\n",
-    "!clang++ -fopenmp -fopenmp-targets=nvptx64 Exercises/exercise2.cpp -o Exercises/exercise2.exe\n",
+    "!srun -N 1 -c 8 clang++ -fopenmp -fopenmp-targets=nvptx64 Exercises/exercise2.cpp -o Exercises/exercise2.exe\n",
     "\n",
     "# Running solution\n",
-    "!Exercises/./exercise2.exe"
+    "!srun -N 1 -c 8 --gres=gpu:1 Exercises/./exercise2.exe"
    ]
   },
   {
@@ -1528,10 +1528,10 @@
    ],
    "source": [
     "# Building Solution\n",
-    "!clang++ -fopenmp -fopenmp-targets=nvptx64 Solutions/exercise2.cpp -o Solutions/exercise2.exe -gline-tables-only\n",
+    "!srun -N 1 -c 8 clang++ -fopenmp -fopenmp-targets=nvptx64 Solutions/exercise2.cpp -o Solutions/exercise2.exe -gline-tables-only\n",
     "\n",
     "# Running solution\n",
-    "!Solutions/./exercise2.exe"
+    "!srun -N 1 -c 8 --gres=gpu:1 Solutions/./exercise2.exe"
    ]
   },
   {

--- a/Labs/Lab4/lab4.2.ipynb
+++ b/Labs/Lab4/lab4.2.ipynb
@@ -140,7 +140,7 @@
    "outputs": [],
    "source": [
     "# Building\n",
-    "!clang -fopenmp -fopenmp-targets=nvptx64 C/target_only.c -o C/./target_only.exe"
+    "!srun -N 1 -c 8 clang -fopenmp -fopenmp-targets=nvptx64 C/target_only.c -o C/./target_only.exe"
    ]
   },
   {
@@ -160,7 +160,7 @@
    ],
    "source": [
     "# Running\n",
-    "!C/./target_only.exe"
+    "!srun -N 1 -c 8 --gres=gpu:1 C/./target_only.exe"
    ]
   },
   {
@@ -208,7 +208,7 @@
    "outputs": [],
    "source": [
     "# Building\n",
-    "!clang -fopenmp -fopenmp-targets=nvptx64 C/teams_only.c -o C/./teams_only.exe"
+    "!srun -N 1 -c 8 clang -fopenmp -fopenmp-targets=nvptx64 C/teams_only.c -o C/./teams_only.exe"
    ]
   },
   {
@@ -353,7 +353,7 @@
     }
    ],
    "source": [
-    "!C/./teams_only.exe"
+    "!srun -N 1 -c 8 --gres=gpu:1 C/./teams_only.exe"
    ]
   },
   {
@@ -400,7 +400,7 @@
    "outputs": [],
    "source": [
     "# Building\n",
-    "!clang -fopenmp -fopenmp-targets=nvptx64 C/parallel_only.c -o C/./parallel_only.exe"
+    "!srun -N 1 -c 8 clang -fopenmp -fopenmp-targets=nvptx64 C/parallel_only.c -o C/./parallel_only.exe"
    ]
   },
   {
@@ -546,7 +546,7 @@
     }
    ],
    "source": [
-    "!C/./parallel_only.exe\n"
+    "!srun -N 1 -c 8 --gres=gpu:1 C/./parallel_only.exe\n"
    ]
   },
   {
@@ -601,7 +601,7 @@
    "outputs": [],
    "source": [
     "# Building\n",
-    "!clang -fopenmp -fopenmp-targets=nvptx64 C/teams_parallel.c -o C/./teams_parallel.exe"
+    "!srun -N 1 -c 8 clang -fopenmp -fopenmp-targets=nvptx64 C/teams_parallel.c -o C/./teams_parallel.exe"
    ]
   },
   {
@@ -787,7 +787,7 @@
     }
    ],
    "source": [
-    "!C/./teams_parallel.exe"
+    "!srun -N 1 -c 8 --gres=gpu:1 C/./teams_parallel.exe"
    ]
   },
   {
@@ -835,7 +835,7 @@
    "outputs": [],
    "source": [
     "# Building\n",
-    "!clang -fopenmp -fopenmp-targets=nvptx64 C/teams_parallel_no_worksharing.c -o C/./teams_parallel_no_worksharing.exe"
+    "!srun -N 1 -c 8 clang -fopenmp -fopenmp-targets=nvptx64 C/teams_parallel_no_worksharing.c -o C/./teams_parallel_no_worksharing.exe"
    ]
   },
   {
@@ -853,7 +853,7 @@
     }
    ],
    "source": [
-    "!C/./teams_parallel_no_worksharing.exe"
+    "!srun -N 1 -c 8 --gres=gpu:1 C/./teams_parallel_no_worksharing.exe"
    ]
   },
   {
@@ -902,7 +902,7 @@
    "outputs": [],
    "source": [
     "# Building\n",
-    "!clang -fopenmp -fopenmp-targets=nvptx64 C/teams_distribute.c -o C/./teams_distribute.exe"
+    "!srun -N 1 -c 8 clang -fopenmp -fopenmp-targets=nvptx64 C/teams_distribute.c -o C/./teams_distribute.exe"
    ]
   },
   {
@@ -928,7 +928,7 @@
     }
    ],
    "source": [
-    "!C/./teams_distribute.exe"
+    "!srun -N 1 -c 8 --gres=gpu:1 C/./teams_distribute.exe"
    ]
   },
   {
@@ -963,7 +963,7 @@
    "outputs": [],
    "source": [
     "# Building\n",
-    "!clang -fopenmp -fopenmp-targets=nvptx64 C/parallel_for.c -o C/./parallel_for.exe"
+    "!srun -N 1 -c 8 clang -fopenmp -fopenmp-targets=nvptx64 C/parallel_for.c -o C/./parallel_for.exe"
    ]
   },
   {
@@ -989,7 +989,7 @@
     }
    ],
    "source": [
-    "!C/./parallel_for.exe"
+    "!srun -N 1 -c 8 --gres=gpu:1 C/./parallel_for.exe"
    ]
   },
   {
@@ -1022,7 +1022,7 @@
    "outputs": [],
    "source": [
     "# Building\n",
-    "!clang -fopenmp -fopenmp-targets=nvptx64 C/teams_distribute_parallel_for.c -o C/./teams_distribute_parallel_for.exe"
+    "!srun -N 1 -c 8 clang -fopenmp -fopenmp-targets=nvptx64 C/teams_distribute_parallel_for.c -o C/./teams_distribute_parallel_for.exe"
    ]
   },
   {
@@ -1048,7 +1048,7 @@
     }
    ],
    "source": [
-    "!C/./teams_distribute_parallel_for.exe"
+    "!srun -N 1 -c 8 --gres=gpu:1 C/./teams_distribute_parallel_for.exe"
    ]
   },
   {
@@ -1094,7 +1094,7 @@
    "outputs": [],
    "source": [
     "# Building\n",
-    "!clang -fopenmp -fopenmp-targets=nvptx64 C/teams_distribute_parallel_for_sched.c -o C/./teams_distribute_parallel_for_sched.exe"
+    "!srun -N 1 -c 8 clang -fopenmp -fopenmp-targets=nvptx64 C/teams_distribute_parallel_for_sched.c -o C/./teams_distribute_parallel_for_sched.exe"
    ]
   },
   {
@@ -1120,7 +1120,7 @@
     }
    ],
    "source": [
-    "!C/./teams_distribute_parallel_for_sched.exe"
+    "!srun -N 1 -c 8 --gres=gpu:1 C/./teams_distribute_parallel_for_sched.exe"
    ]
   },
   {
@@ -1158,10 +1158,10 @@
    ],
    "source": [
     "# Building Solution\n",
-    "!clang -fopenmp -fopenmp-targets=nvptx64 -lm Exercises/exercise3.c -o Exercises/exercise3.exe\n",
+    "!srun -N 1 -c 8 clang -fopenmp -fopenmp-targets=nvptx64 -lm Exercises/exercise3.c -o Exercises/exercise3.exe\n",
     "\n",
     "# Running solution\n",
-    "!Exercises/./exercise3.exe"
+    "!srun -N 1 -c 8 --gres=gpu:1 Exercises/./exercise3.exe"
    ]
   },
   {
@@ -1189,10 +1189,10 @@
    ],
    "source": [
     "# Building Solution\n",
-    "!clang -fopenmp -fopenmp-targets=nvptx64 -lm Solutions/exercise3.c -o Solutions/exercise3.exe\n",
+    "!srun -N 1 -c 8 clang -fopenmp -fopenmp-targets=nvptx64 -lm Solutions/exercise3.c -o Solutions/exercise3.exe\n",
     "\n",
     "# Running solution\n",
-    "!Solutions/./exercise3.exe"
+    "!srun -N 1 -c 8 --gres=gpu:1 Solutions/./exercise3.exe"
    ]
   },
   {


### PR DESCRIPTION
## HPCSS2026: dispatch OpenMP lab cells onto the Slurm compute nodes

Adapts the OpenMP labs for the **2026 HPC Summer School** Chameleon cluster, mirroring the `ss2023`/`ss2024`/`ss2025` summer-school branches: every in-notebook command runs on a compute node via `srun` instead of on the JupyterHub login node.

### What changed — **source command lines only**
This is a minimal, source-only diff: **cell outputs, `execution_count`, metadata, and JSON formatting are preserved byte-for-byte** (verified). 159 command lines changed; markdown untouched.

- **CPU cells** → `srun -N 1 -c 8 <cmd>` (8 cores → OpenMP threads). `cons_tres`/`CR_Core` lets many students share a 48-core node.
- **OpenMP env vars stay before `srun`** (`OMP_NUM_THREADS=3 srun … ./prog`) so they propagate into the job.
- **`&&` compile+run lines** keep the chain (`srun … gcc … && ./exe`), as in prior years.
- **Lab 4 GPU offload runs** → `srun -N 1 -c 8 --gres=gpu:1`; compiles stay CPU-only. *(The only 2026-specific addition — Slurm GRES was configured this year; see below.)*

### Faithful to prior years (left exactly as upstream)
- **Introspection cells** (`nvidia-smi`, `rocm-info`, `llvm-omp-device-info`, `lscpu`) run on the login node, **not** `srun`-wrapped.
- **Deadlock demo** (`lock_program`) unchanged — no added `timeout`.

### Cluster-side prerequisites (already applied + logged — cybercolombia/hpcss_cluster#1)
- **clang-19 GPU offload fix** on all 13 nodes (NVPTX device bitcode on clang's search path + `libomptarget.so` on the loader path).
- **Slurm GPU GRES** (`Gres=gpu:1` on ss-01…ss-13 + `gres.conf`) → `--gres=gpu:1` schedules one GPU per node.

### Testing (on the live cluster)
- ✅ CPU compile+run on compute nodes; `OMP_NUM_THREADS=N` honored; race loop; `matrix_mult -O3` parallel speedup; deadlock caught by the existing `timeout` cell.
- ✅ GPU offload: `OMP_TARGET_OFFLOAD=disabled`→Host, `mandatory`→Device; `--gres=gpu:1` sets `CUDA_VISIBLE_DEVICES`.

### Pre-existing issues surfaced (NOT addressed here — not scheduler-related)
- `Lab4/Solutions/exercise2.cpp` compiles but **segfaults on the GPU** under clang-19/CUDA-12.6.
- `Lab2/Exercises/critical_region_queue.exe` (unsolved student stub) **hangs** when run to completion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
